### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.automation.actions/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.automation.actions/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.automation.actions.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.automation.actions/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.automation.actions.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.automation.actions)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.automation.actions.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.automation.actions)
 
 ## Overview
 


### PR DESCRIPTION
## Purpose

Fix a documentation issue in the top-level `README.md` identified in the HubSpot connector documentation audit.

The GitHub Issues badge link URL was half-encoded (`module%hubspot.automation.actions`); replaced with the correctly encoded `module%2Fhubspot.automation.actions` so the badge link resolves to the proper label filter.

Refs ballerina-platform/ballerina-library#8823

## Examples

N/A — documentation-only change.

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog — N/A, documentation-only change
- [ ] Added tests — N/A, documentation-only change
- [ ] Updated the spec — N/A, documentation-only change
- [ ] Checked native-image compatibility — N/A, documentation-only change