### PR TITLE
docs: improve operation summaries and add field descriptions

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -38,6 +38,7 @@ public isolated client class Client {
 
     # Completes a single callback
     #
+    # + callbackId - Unique identifier of the callback to complete.
     # + headers - Headers to be sent with the request 
     # + return - No content 
     resource isolated function post callbacks/[string callbackId]/complete(CallbackCompletionRequest payload, map<string|string[]> headers = {}) returns error? {
@@ -72,6 +73,7 @@ public isolated client class Client {
 
     # Get paged extension definitions
     #
+    # + appId - The integer ID of the app whose action definitions are retrieved.
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -87,6 +89,7 @@ public isolated client class Client {
 
     # Create a new extension definition
     #
+    # + appId - The integer ID of the app for which a new action definition is created.
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     resource isolated function post [int:Signed32 appId](PublicActionDefinitionEgg payload, map<string|string[]> headers = {}) returns PublicActionDefinition|error {
@@ -102,8 +105,10 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, headers);
     }
 
-    # Get all functions for a given definition
+    # List functions for a definition
     #
+    # + definitionId - The unique ID of the action definition whose functions are listed.
+    # + appId - The integer ID of the app owning the action definition.
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     resource isolated function get [int:Signed32 appId]/[string definitionId]/functions(map<string|string[]> headers = {}) returns CollectionResponsePublicActionFunctionIdentifierNoPaging|error {
@@ -116,8 +121,11 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, headers);
     }
 
-    # Get all functions by a type for a given definition
+    # List functions by type
     #
+    # + definitionId - The unique ID of the action definition to retrieve the function from.
+    # + functionType - The function type to retrieve. Allowed: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION.
+    # + appId - The integer ID of the app associated with the action definition.
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     resource isolated function get [int:Signed32 appId]/[string definitionId]/functions/["PRE_ACTION_EXECUTION"|"PRE_FETCH_OPTIONS"|"POST_FETCH_OPTIONS"|"POST_ACTION_EXECUTION" functionType](map<string|string[]> headers = {}) returns PublicActionFunction|error {
@@ -132,6 +140,9 @@ public isolated client class Client {
 
     # Insert a function for a definition
     #
+    # + definitionId - The unique ID of the action definition to create or replace the function on.
+    # + functionType - The function type to create or replace. Allowed: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION.
+    # + appId - The unique identifier of the app to associate with the function type.
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     resource isolated function put [int:Signed32 appId]/[string definitionId]/functions/["PRE_ACTION_EXECUTION"|"PRE_FETCH_OPTIONS"|"POST_FETCH_OPTIONS"|"POST_ACTION_EXECUTION" functionType](string payload, map<string|string[]> headers = {}) returns PublicActionFunctionIdentifier|error {
@@ -148,6 +159,9 @@ public isolated client class Client {
 
     # Delete a function for a definition
     #
+    # + definitionId - The unique identifier of the action definition whose function type will be archived.
+    # + functionType - The function type to archive. Allowed values: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION.
+    # + appId - The unique identifier of the app whose function type will be archived.
     # + headers - Headers to be sent with the request 
     # + return - No content 
     resource isolated function delete [int:Signed32 appId]/[string definitionId]/functions/["PRE_ACTION_EXECUTION"|"PRE_FETCH_OPTIONS"|"POST_FETCH_OPTIONS"|"POST_ACTION_EXECUTION" functionType](map<string|string[]> headers = {}) returns error? {
@@ -160,8 +174,11 @@ public isolated client class Client {
         return self.clientEp->delete(resourcePath, headers = headers);
     }
 
-    # Gets a revision for a given definition by revision id
+    # Get a definition revision by ID
     #
+    # + definitionId - The unique identifier of the action definition whose revision will be retrieved.
+    # + revisionId - The unique identifier of the revision to retrieve.
+    # + appId - The unique identifier of the app associated with the definition revision.
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     resource isolated function get [int:Signed32 appId]/[string definitionId]/revisions/[string revisionId](map<string|string[]> headers = {}) returns PublicActionRevision|error {
@@ -176,6 +193,8 @@ public isolated client class Client {
 
     # Get extension definition by Id
     #
+    # + definitionId - The unique identifier of the action definition to retrieve.
+    # + appId - The unique identifier of the app associated with the action definition.
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -191,6 +210,8 @@ public isolated client class Client {
 
     # Archive an extension definition
     #
+    # + definitionId - The unique identifier of the action definition to archive.
+    # + appId - The unique identifier of the app whose action definition will be archived.
     # + headers - Headers to be sent with the request 
     # + return - No content 
     resource isolated function delete [int:Signed32 appId]/[string definitionId](map<string|string[]> headers = {}) returns error? {
@@ -203,8 +224,10 @@ public isolated client class Client {
         return self.clientEp->delete(resourcePath, headers = headers);
     }
 
-    # Patch an existing extension definition
+    # Patch an extension definition
     #
+    # + definitionId - The unique identifier of the action definition to update.
+    # + appId - The unique identifier of the app associated with the action definition to update.
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     resource isolated function patch [int:Signed32 appId]/[string definitionId](PublicActionDefinitionPatch payload, map<string|string[]> headers = {}) returns PublicActionDefinition|error {
@@ -222,6 +245,10 @@ public isolated client class Client {
 
     # Get a function for a given definition
     #
+    # + definitionId - The unique identifier of the action definition containing the target function.
+    # + functionType - The function type to retrieve. Allowed values: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION.
+    # + functionId - The unique identifier of the function to retrieve.
+    # + appId - The unique identifier of the app associated with the function to retrieve.
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     resource isolated function get [int:Signed32 appId]/[string definitionId]/functions/["PRE_ACTION_EXECUTION"|"PRE_FETCH_OPTIONS"|"POST_FETCH_OPTIONS"|"POST_ACTION_EXECUTION" functionType]/[string functionId](map<string|string[]> headers = {}) returns PublicActionFunction|error {
@@ -236,6 +263,10 @@ public isolated client class Client {
 
     # Insert a function for a definition
     #
+    # + definitionId - The unique identifier of the action definition for the function to create or replace.
+    # + functionType - The function type to create or replace. Allowed values: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION.
+    # + functionId - The unique identifier of the function to create or replace.
+    # + appId - The unique numeric identifier of the app owning the definition.
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     resource isolated function put [int:Signed32 appId]/[string definitionId]/functions/["PRE_ACTION_EXECUTION"|"PRE_FETCH_OPTIONS"|"POST_FETCH_OPTIONS"|"POST_ACTION_EXECUTION" functionType]/[string functionId](string payload, map<string|string[]> headers = {}) returns PublicActionFunctionIdentifier|error {
@@ -252,6 +283,10 @@ public isolated client class Client {
 
     # Archive a function for a definition
     #
+    # + definitionId - The unique identifier of the extension definition containing the function.
+    # + functionType - The execution stage of the function. Must be one of: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION.
+    # + functionId - The unique identifier of the function to delete.
+    # + appId - The unique numeric identifier of the app owning the definition.
     # + headers - Headers to be sent with the request 
     # + return - No content 
     resource isolated function delete [int:Signed32 appId]/[string definitionId]/functions/["PRE_ACTION_EXECUTION"|"PRE_FETCH_OPTIONS"|"POST_FETCH_OPTIONS"|"POST_ACTION_EXECUTION" functionType]/[string functionId](map<string|string[]> headers = {}) returns error? {
@@ -264,8 +299,10 @@ public isolated client class Client {
         return self.clientEp->delete(resourcePath, headers = headers);
     }
 
-    # Get all revisions for a given definition
+    # List all definition revisions
     #
+    # + definitionId - The unique identifier of the extension definition whose revisions are retrieved.
+    # + appId - The unique numeric identifier of the app owning the definition.
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -16,85 +16,146 @@
 
 import ballerina/http;
 
+# Defines a serverless function associated with an automation action, including its source code and execution lifecycle type.
 public type PublicActionFunction record {
+    # The source code of the function.
     string functionSource;
+    # The lifecycle stage at which the function executes.
     "PRE_ACTION_EXECUTION"|"PRE_FETCH_OPTIONS"|"POST_FETCH_OPTIONS"|"POST_ACTION_EXECUTION" functionType;
+    # The unique identifier of the function.
     string id?;
 };
 
+# Defines a custom automation action, including its endpoint, input/output fields, labels, associated functions, and publication state.
 public type PublicActionDefinition record {
+    # List of function identifiers associated with this action.
     PublicActionFunctionIdentifier[] functions;
+    # The URL endpoint invoked when the action executes.
     string actionUrl;
+    # Indicates whether the action is published and available for use.
     boolean published;
+    # Localized display labels for the action, keyed by language code.
     record {|PublicActionLabels...;|} labels;
+    # List of input fields the action accepts during execution.
     InputFieldDefinition[] inputFields;
+    # List of output fields the action returns after execution.
     OutputFieldDefinition[] outputFields?;
+    # The identifier of the current revision of the action definition.
     string revisionId;
+    # Timestamp (ms) when the action was archived, if applicable.
     int archivedAt?;
+    # Conditional dependencies that control input field visibility or behavior.
     PublicActionDefinitionInputFieldDependencies[] inputFieldDependencies?;
+    # Rules that govern how the action execution is translated or applied.
     PublicExecutionTranslationRule[] executionRules?;
+    # The unique identifier of the action definition.
     string id;
+    # CRM object types this action can be applied to.
     string[] objectTypes;
+    # Options for a public object request, specifying which properties to retrieve.
     PublicObjectRequestOptions objectRequestOptions?;
 };
 
+# Defines a conditional dependency where dependent fields are shown or hidden based on a single controlling field's value.
 public type PublicConditionalSingleFieldDependency record {
+    # The type of field dependency; always CONDITIONAL_SINGLE_FIELD.
     "CONDITIONAL_SINGLE_FIELD" dependencyType = "CONDITIONAL_SINGLE_FIELD";
+    # Name of the field that controls the dependency.
     string controllingFieldName;
+    # The value of the controlling field that triggers the dependency.
     string controllingFieldValue;
+    # List of field names dependent on the controlling field's value.
     string[] dependentFieldNames;
 };
 
+# Defines a field dependency as either a single-field or conditional single-field dependency type.
 public type PublicActionDefinitionInputFieldDependencies PublicSingleFieldDependency|PublicConditionalSingleFieldDependency;
 
+# Options for a public object request, specifying which properties to retrieve.
 public type PublicObjectRequestOptions record {
+    # List of property names to include in the object response.
     string[] properties;
 };
 
+# Localized display labels for an action, including field labels, descriptions, and card content.
 public type PublicActionLabels record {
+    # Map of input field names to their descriptive text.
     record {|string...;|} inputFieldDescriptions?;
+    # Display name of the app associated with the action.
     string appDisplayName?;
+    # Map of output field names to their display labels.
     record {|string...;|} outputFieldLabels?;
+    # Nested map of input field option keys to their display labels.
     record {|record {|string...;|}...;|} inputFieldOptionLabels?;
+    # Human-readable description of the action's purpose.
     string actionDescription?;
+    # Map of execution rule keys to their display label strings.
     record {|string...;|} executionRules?;
+    # Map of input field names to their display labels.
     record {|string...;|} inputFieldLabels?;
+    # Display name of the action.
     string actionName;
+    # Text content displayed on the action's summary card.
     string actionCardContent?;
 };
 
+# Defines a SINGLE_FIELD dependency linking a controlling field to one or more dependent fields.
 public type PublicSingleFieldDependency record {
+    # The type of field dependency; always 'SINGLE_FIELD'.
     "SINGLE_FIELD" dependencyType = "SINGLE_FIELD";
+    # The name of the field that controls the dependency.
     string controllingFieldName;
+    # List of field names dependent on the controlling field.
     string[] dependentFieldNames;
 };
 
+# Pagination wrapper containing a reference to the next page of results.
 public type ForwardPaging record {
+    # Pagination cursor object used to retrieve the next page of results.
     NextPage next?;
 };
 
+# Defines the type, display, and option configuration for an action input field.
 public type FieldTypeDefinition record {
+    # Supplementary help text displayed alongside the field.
     string helpText?;
+    # The HubSpot object type this field references.
     "CONTACT"|"COMPANY"|"DEAL"|"ENGAGEMENT"|"TICKET"|"OWNER"|"PRODUCT"|"LINE_ITEM"|"BET_DELIVERABLE_SERVICE"|"CONTENT"|"CONVERSATION"|"BET_ALERT"|"PORTAL"|"QUOTE"|"FORM_SUBMISSION_INBOUNDDB"|"QUOTA"|"UNSUBSCRIBE"|"COMMUNICATION"|"FEEDBACK_SUBMISSION"|"ATTRIBUTION"|"SALESFORCE_SYNC_ERROR"|"RESTORABLE_CRM_OBJECT"|"HUB"|"LANDING_PAGE"|"PRODUCT_OR_FOLDER"|"TASK"|"FORM"|"MARKETING_EMAIL"|"AD_ACCOUNT"|"AD_CAMPAIGN"|"AD_GROUP"|"AD"|"KEYWORD"|"CAMPAIGN"|"SOCIAL_CHANNEL"|"SOCIAL_POST"|"SITE_PAGE"|"BLOG_POST"|"IMPORT"|"EXPORT"|"CTA"|"TASK_TEMPLATE"|"AUTOMATION_PLATFORM_FLOW"|"OBJECT_LIST"|"NOTE"|"MEETING_EVENT"|"CALL"|"EMAIL"|"PUBLISHING_TASK"|"CONVERSATION_SESSION"|"CONTACT_CREATE_ATTRIBUTION"|"INVOICE"|"MARKETING_EVENT"|"CONVERSATION_INBOX"|"CHATFLOW"|"MEDIA_BRIDGE"|"SEQUENCE"|"SEQUENCE_STEP"|"FORECAST"|"SNIPPET"|"TEMPLATE"|"DEAL_CREATE_ATTRIBUTION"|"QUOTE_TEMPLATE"|"QUOTE_MODULE"|"QUOTE_MODULE_FIELD"|"QUOTE_FIELD"|"SEQUENCE_ENROLLMENT"|"SUBSCRIPTION"|"ACCEPTANCE_TEST"|"SOCIAL_BROADCAST"|"DEAL_SPLIT"|"DEAL_REGISTRATION"|"GOAL_TARGET"|"GOAL_TARGET_GROUP"|"PORTAL_OBJECT_SYNC_MESSAGE"|"FILE_MANAGER_FILE"|"FILE_MANAGER_FOLDER"|"SEQUENCE_STEP_ENROLLMENT"|"APPROVAL"|"APPROVAL_STEP"|"CTA_VARIANT"|"SALES_DOCUMENT"|"DISCOUNT"|"FEE"|"TAX"|"MARKETING_CALENDAR"|"PERMISSIONS_TESTING"|"PRIVACY_SCANNER_COOKIE"|"DATA_SYNC_STATE"|"WEB_INTERACTIVE"|"PLAYBOOK"|"FOLDER"|"PLAYBOOK_QUESTION"|"PLAYBOOK_SUBMISSION"|"PLAYBOOK_SUBMISSION_ANSWER"|"COMMERCE_PAYMENT"|"GSC_PROPERTY"|"SOX_PROTECTED_DUMMY_TYPE"|"BLOG_LISTING_PAGE"|"QUARANTINED_SUBMISSION"|"PAYMENT_SCHEDULE"|"PAYMENT_SCHEDULE_INSTALLMENT"|"MARKETING_CAMPAIGN_UTM"|"DISCOUNT_TEMPLATE"|"DISCOUNT_CODE"|"FEEDBACK_SURVEY"|"CMS_URL"|"SALES_TASK"|"SALES_WORKLOAD"|"USER"|"POSTAL_MAIL"|"SCHEMAS_BACKEND_TEST"|"PAYMENT_LINK"|"SUBMISSION_TAG"|"CAMPAIGN_STEP"|"SCHEDULING_PAGE"|"SOX_PROTECTED_TEST_TYPE"|"ORDER"|"MARKETING_SMS"|"PARTNER_ACCOUNT"|"CAMPAIGN_TEMPLATE"|"CAMPAIGN_TEMPLATE_STEP"|"PLAYLIST"|"CLIP"|"CAMPAIGN_BUDGET_ITEM"|"CAMPAIGN_SPEND_ITEM"|"MIC"|"CONTENT_AUDIT"|"CONTENT_AUDIT_PAGE"|"PLAYLIST_FOLDER"|"LEAD"|"ABANDONED_CART"|"EXTERNAL_WEB_URL"|"VIEW"|"VIEW_BLOCK"|"ROSTER"|"CART"|"AUTOMATION_PLATFORM_FLOW_ACTION"|"SOCIAL_PROFILE"|"PARTNER_CLIENT"|"ROSTER_MEMBER"|"MARKETING_EVENT_ATTENDANCE"|"ALL_PAGES"|"AI_FORECAST"|"CRM_PIPELINES_DUMMY_TYPE"|"KNOWLEDGE_ARTICLE"|"PROPERTY_INFO"|"DATA_PRIVACY_CONSENT"|"GOAL_TEMPLATE"|"SCORE_CONFIGURATION"|"AUDIENCE"|"PARTNER_CLIENT_REVENUE"|"AUTOMATION_JOURNEY"|"UNKNOWN" referencedObjectType?;
+    # The internal name identifier of the field type.
     string name;
+    # List of selectable options available for the field.
     Option[] options;
+    # A human-readable description of the field type.
     string description?;
+    # Reference type used to resolve externally sourced options.
     string externalOptionsReferenceType?;
+    # The display label shown to users for the field.
     string label?;
+    # The data type of the field value (e.g., string, number, bool).
     "string"|"number"|"bool"|"datetime"|"enumeration"|"date"|"phone_number"|"currency_number"|"json"|"object_coordinates" 'type;
+    # The UI control type used to render the field.
     "booleancheckbox"|"checkbox"|"date"|"file"|"number"|"phonenumber"|"radio"|"select"|"text"|"textarea"|"calculation_equation"|"calculation_rollup"|"calculation_score"|"calculation_read_time"|"unknown"|"html" fieldType?;
+    # URL endpoint for fetching field options dynamically.
     string optionsUrl?;
+    # Indicates whether options are loaded from an external source.
     boolean externalOptions;
 };
 
+# Defines an input field for an action, including its type and accepted value sources.
 public type InputFieldDefinition record {
+    # Indicates whether the input field is required.
     boolean isRequired;
+    # The automation-specific field type identifier.
     string automationFieldType?;
+    # Defines the type, display, and option configuration for an action input field.
     FieldTypeDefinition typeDefinition;
+    # List of value types accepted by this input field.
     ("STATIC_VALUE"|"OBJECT_PROPERTY"|"FIELD_DATA"|"FETCHED_OBJECT_PROPERTY"|"ENROLLMENT_EVENT_PROPERTY")[] supportedValueTypes?;
 };
 
+# A collection of action function identifiers returned without paging.
 public type CollectionResponsePublicActionFunctionIdentifierNoPaging record {
+    # List of action function identifiers in the response.
     PublicActionFunctionIdentifier[] results;
 };
 
@@ -115,13 +176,19 @@ public type GetAppIdGetPageQueries record {
     string after?;
 };
 
+# Defines a translation rule mapping execution conditions to a display label.
 public type PublicExecutionTranslationRule record {
+    # The display label name for this translation rule.
     string labelName;
+    # Key-value map of conditions that trigger this translation rule.
     record {|record {}...;|} conditions;
 };
 
+# Identifies a function associated with a public action by type and optional ID.
 public type PublicActionFunctionIdentifier record {
+    # The execution stage at which this function is invoked.
     "PRE_ACTION_EXECUTION"|"PRE_FETCH_OPTIONS"|"POST_FETCH_OPTIONS"|"POST_ACTION_EXECUTION" functionType;
+    # The unique identifier of the action function.
     string id?;
 };
 
@@ -169,27 +236,40 @@ public type ConnectionConfig record {|
     boolean laxDataBinding = true;
 |};
 
+# Represents a versioned revision of a public action definition.
 public type PublicActionRevision record {
+    # The unique identifier for this action revision.
     string revisionId;
+    # The timestamp when this revision was created.
     string createdAt;
+    # Defines a custom automation action, including its endpoint, input/output fields, labels, associated functions, and publication state.
     PublicActionDefinition definition;
+    # The unique identifier of the action revision record.
     string id;
 };
 
+# Request payload for completing an action callback with output field values.
 public type CallbackCompletionRequest record {
     record {|string...;|} outputFields;
 };
 
+# A paginated collection of public action definitions with forward paging support.
 public type CollectionResponsePublicActionDefinitionForwardPaging record {
+    # Pagination wrapper containing a reference to the next page of results.
     ForwardPaging paging?;
+    # The list of returned public action definitions.
     PublicActionDefinition[] results;
 };
 
+# Paginated collection of public action revision records
 public type CollectionResponsePublicActionRevisionForwardPaging record {
+    # Pagination wrapper containing a reference to the next page of results.
     ForwardPaging paging?;
+    # Array of public action revision objects returned in this page
     PublicActionRevision[] results;
 };
 
+# Input field dependency definition; either a single or conditional single field dependency
 public type PublicActionDefinitionEggInputFieldDependencies PublicSingleFieldDependency|PublicConditionalSingleFieldDependency;
 
 # Represents the Queries record for the operation: get-/{appId}/{definitionId}_getById
@@ -198,59 +278,100 @@ public type GetAppIdDefinitionIdGetByIdQueries record {
     boolean archived = false;
 };
 
+# Request payload for completing a batch callback with output field values
 public type CallbackCompletionBatchRequest record {
+    # Key-value map of output field names to their resolved string values
     record {|string...;|} outputFields;
+    # Unique identifier of the callback to complete
     string callbackId;
 };
 
+# Request payload for creating a new custom automation action definition
 public type PublicActionDefinitionEgg record {
+    # Array of input field definitions accepted by this action
     InputFieldDefinition[] inputFields;
+    # Array of output field definitions produced by this action
     OutputFieldDefinition[] outputFields?;
+    # Timestamp (ms) indicating when the action definition was archived
     int archivedAt?;
+    # Array of serverless functions associated with this action
     PublicActionFunction[] functions;
+    # Endpoint URL invoked when this action executes
     string actionUrl;
+    # Array of dependency rules governing input field visibility or behavior
     PublicActionDefinitionEggInputFieldDependencies[] inputFieldDependencies?;
+    # Indicates whether this action definition is publicly published
     boolean published;
+    # Array of rules controlling when and how this action executes
     PublicExecutionTranslationRule[] executionRules?;
+    # CRM object types this action is applicable to
     string[] objectTypes;
+    # Options for a public object request, specifying which properties to retrieve.
     PublicObjectRequestOptions objectRequestOptions?;
+    # Localized display labels for the action, keyed by language code.
     record {|PublicActionLabels...;|} labels;
 };
 
+# Partial update payload for modifying an existing custom action definition.
 public type PublicActionDefinitionPatch record {
+    # Updated list of input field definitions for the action.
     InputFieldDefinition[] inputFields?;
+    # Updated list of output field definitions returned by the action.
     OutputFieldDefinition[] outputFields?;
+    # The URL endpoint invoked when the action executes.
     string actionUrl?;
+    # Conditional dependencies controlling input field visibility or behavior.
     PublicActionDefinitionPatchInputFieldDependencies[] inputFieldDependencies?;
+    # Whether the action is published and available for use in workflows.
     boolean published?;
+    # Rules that govern how and when the action execution is translated.
     PublicExecutionTranslationRule[] executionRules?;
+    # CRM object types this action is applicable to.
     string[] objectTypes?;
+    # Options for a public object request, specifying which properties to retrieve.
     PublicObjectRequestOptions objectRequestOptions?;
+    # Localized display labels for the action, keyed by language code.
     record {|PublicActionLabels...;|} labels?;
 };
 
+# A batch of callback completion requests to resolve multiple pending action callbacks.
 public type BatchInputCallbackCompletionBatchRequest record {
+    # Array of individual callback completion requests in the batch.
     CallbackCompletionBatchRequest[] inputs;
 };
 
+# A field dependency rule; either a single-field or conditional single-field dependency.
 public type PublicActionDefinitionPatchInputFieldDependencies PublicSingleFieldDependency|PublicConditionalSingleFieldDependency;
 
+# A selectable option for an input field, including its label, value, and display metadata.
 public type Option record {
+    # Whether this option is hidden from the user interface.
     boolean hidden;
+    # Numeric order in which the option appears in the UI.
     int:Signed32 displayOrder;
+    # Numeric double value associated with the option.
     decimal doubleData;
+    # Human-readable description of the option.
     string description;
+    # Indicates whether the option is read-only.
     boolean readOnly;
+    # Display label shown to users for the option.
     string label;
+    # Stored string value representing the option.
     string value;
 };
 
+# Defines an output field, including its type definition for an automation action.
 public type OutputFieldDefinition record {
+    # Defines the type, display, and option configuration for an action input field.
     FieldTypeDefinition typeDefinition;
 };
 
+# Pagination cursor object used to retrieve the next page of results.
 public type NextPage record {
+    # URL link to the next page of results.
     string link?;
+    # Cursor token used to fetch the next page of results.
     string after;
 };
 

--- a/docs/spec/aligned_ballerina_openapi.json
+++ b/docs/spec/aligned_ballerina_openapi.json
@@ -1,0 +1,2269 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Automation Actions V4",
+        "version": "v4",
+        "x-hubspot-product-tier-requirements": {
+            "marketing": "PROFESSIONAL",
+            "sales": "PROFESSIONAL",
+            "service": "PROFESSIONAL"
+        },
+        "x-hubspot-documentation-banner": "NONE",
+        "x-hubspot-api-use-case": "You want to empower other users in your account to automate specialized parts of their day-to-day processes (e.g., creating highly customized quotes based on the data from an enrolled contact and their associations).",
+        "x-hubspot-related-documentation": [
+            {
+                "name": "Custom Workflow Actions Guide",
+                "url": "https://developers.hubspot.com/beta-docs/guides/api/automation/custom-workflow-actions"
+            }
+        ],
+        "x-hubspot-introduction": "Use the automation API to define custom actions in the HubSpot workflows tool, which allows users in your account to integrate with external services as they build out a HubSpot workflow."
+    },
+    "servers": [
+        {
+            "url": "https://api.hubapi.com/automation/v4/actions"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Callbacks"
+        },
+        {
+            "name": "Definitions"
+        },
+        {
+            "name": "Functions"
+        },
+        {
+            "name": "Revisions"
+        }
+    ],
+    "paths": {
+        "/callbacks/{callbackId}/complete": {
+            "post": {
+                "tags": [
+                    "Callbacks"
+                ],
+                "summary": "Completes a single callback",
+                "operationId": "post-/callbacks/{callbackId}/complete_complete",
+                "parameters": [
+                    {
+                        "name": "callbackId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Unique identifier of the callback to complete."
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CallbackCompletionRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "automation"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "automation"
+                        ]
+                    }
+                ],
+                "description": "Completes the specified callback action. Returns no content on success."
+            }
+        },
+        "/callbacks/complete": {
+            "post": {
+                "tags": [
+                    "Callbacks"
+                ],
+                "summary": "Completes a batch of callbacks",
+                "operationId": "post-/callbacks/complete_completeBatch",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputCallbackCompletionBatchRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "automation"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "automation"
+                        ]
+                    }
+                ],
+                "description": "Completes a batch of callback actions in a single request. Returns no content on success."
+            }
+        },
+        "/{appId}": {
+            "get": {
+                "tags": [
+                    "Definitions"
+                ],
+                "summary": "Get paged extension definitions",
+                "operationId": "get-/{appId}_getPage",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of results to display per page",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "description": "The paging cursor token of the last successfully read resource will be returned as the `paging.next.after` JSON property of a paged response containing more results",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The integer ID of the app whose action definitions are retrieved."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponsePublicActionDefinitionForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns a paginated list of automation action extension definitions for the specified app."
+            },
+            "post": {
+                "tags": [
+                    "Definitions"
+                ],
+                "summary": "Create a new extension definition",
+                "operationId": "post-/{appId}_create",
+                "parameters": [
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The integer ID of the app for which a new action definition is created."
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PublicActionDefinitionEgg"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PublicActionDefinition"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns the newly created automation action extension definition for the specified app."
+            }
+        },
+        "/{appId}/{definitionId}/functions": {
+            "get": {
+                "tags": [
+                    "Functions"
+                ],
+                "summary": "List functions for a definition",
+                "operationId": "get-/{appId}/{definitionId}/functions_getPage",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique ID of the action definition whose functions are listed."
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The integer ID of the app owning the action definition."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponsePublicActionFunctionIdentifierNoPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns all functions associated with the specified automation action extension definition."
+            }
+        },
+        "/{appId}/{definitionId}/functions/{functionType}": {
+            "get": {
+                "tags": [
+                    "Functions"
+                ],
+                "summary": "List functions by type",
+                "operationId": "get-/{appId}/{definitionId}/functions/{functionType}_getByFunctionType",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique ID of the action definition to retrieve the function from."
+                    },
+                    {
+                        "name": "functionType",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "PRE_ACTION_EXECUTION",
+                                "PRE_FETCH_OPTIONS",
+                                "POST_FETCH_OPTIONS",
+                                "POST_ACTION_EXECUTION"
+                            ]
+                        },
+                        "description": "The function type to retrieve. Allowed: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION."
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The integer ID of the app associated with the action definition."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PublicActionFunction"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns all functions matching the specified type for the given extension definition."
+            },
+            "put": {
+                "tags": [
+                    "Functions"
+                ],
+                "summary": "Insert a function for a definition",
+                "operationId": "put-/{appId}/{definitionId}/functions/{functionType}_createOrReplaceByFunctionType",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique ID of the action definition to create or replace the function on."
+                    },
+                    {
+                        "name": "functionType",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "PRE_ACTION_EXECUTION",
+                                "PRE_FETCH_OPTIONS",
+                                "POST_FETCH_OPTIONS",
+                                "POST_ACTION_EXECUTION"
+                            ]
+                        },
+                        "description": "The function type to create or replace. Allowed: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION."
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The unique identifier of the app to associate with the function type."
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "text/plain": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PublicActionFunctionIdentifier"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns the created or replaced function of the specified type for the given extension definition."
+            },
+            "delete": {
+                "tags": [
+                    "Functions"
+                ],
+                "summary": "Delete a function for a definition",
+                "operationId": "delete-/{appId}/{definitionId}/functions/{functionType}_archiveByFunctionType",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the action definition whose function type will be archived."
+                    },
+                    {
+                        "name": "functionType",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "PRE_ACTION_EXECUTION",
+                                "PRE_FETCH_OPTIONS",
+                                "POST_FETCH_OPTIONS",
+                                "POST_ACTION_EXECUTION"
+                            ]
+                        },
+                        "description": "The function type to archive. Allowed values: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION."
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The unique identifier of the app whose function type will be archived."
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Deletes all functions of the specified type for the given definition. Returns no content on success."
+            }
+        },
+        "/{appId}/{definitionId}/revisions/{revisionId}": {
+            "get": {
+                "tags": [
+                    "Revisions"
+                ],
+                "summary": "Get a definition revision by ID",
+                "operationId": "get-/{appId}/{definitionId}/revisions/{revisionId}_getById",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the action definition whose revision will be retrieved."
+                    },
+                    {
+                        "name": "revisionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the revision to retrieve."
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The unique identifier of the app associated with the definition revision."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PublicActionRevision"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns a specific revision of the extension definition identified by the given revision ID."
+            }
+        },
+        "/{appId}/{definitionId}": {
+            "get": {
+                "tags": [
+                    "Definitions"
+                ],
+                "summary": "Get extension definition by Id",
+                "operationId": "get-/{appId}/{definitionId}_getById",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the action definition to retrieve."
+                    },
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The unique identifier of the app associated with the action definition."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PublicActionDefinition"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns the automation action extension definition matching the specified definition ID."
+            },
+            "delete": {
+                "tags": [
+                    "Definitions"
+                ],
+                "summary": "Archive an extension definition",
+                "operationId": "delete-/{appId}/{definitionId}_archive",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the action definition to archive."
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The unique identifier of the app whose action definition will be archived."
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Archives the specified extension definition. Returns no content on success."
+            },
+            "patch": {
+                "tags": [
+                    "Definitions"
+                ],
+                "summary": "Patch an extension definition",
+                "operationId": "patch-/{appId}/{definitionId}_update",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the action definition to update."
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The unique identifier of the app associated with the action definition to update."
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PublicActionDefinitionPatch"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PublicActionDefinition"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns the updated automation action extension definition after applying the provided partial changes."
+            }
+        },
+        "/{appId}/{definitionId}/functions/{functionType}/{functionId}": {
+            "get": {
+                "tags": [
+                    "Functions"
+                ],
+                "summary": "Get a function for a given definition",
+                "operationId": "get-/{appId}/{definitionId}/functions/{functionType}/{functionId}_getById",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the action definition containing the target function."
+                    },
+                    {
+                        "name": "functionType",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "PRE_ACTION_EXECUTION",
+                                "PRE_FETCH_OPTIONS",
+                                "POST_FETCH_OPTIONS",
+                                "POST_ACTION_EXECUTION"
+                            ]
+                        },
+                        "description": "The function type to retrieve. Allowed values: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION."
+                    },
+                    {
+                        "name": "functionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the function to retrieve."
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The unique identifier of the app associated with the function to retrieve."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PublicActionFunction"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns the function matching the specified type and function ID for the given extension definition."
+            },
+            "put": {
+                "tags": [
+                    "Functions"
+                ],
+                "summary": "Insert a function for a definition",
+                "operationId": "put-/{appId}/{definitionId}/functions/{functionType}/{functionId}_createOrReplace",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the action definition for the function to create or replace."
+                    },
+                    {
+                        "name": "functionType",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "PRE_ACTION_EXECUTION",
+                                "PRE_FETCH_OPTIONS",
+                                "POST_FETCH_OPTIONS",
+                                "POST_ACTION_EXECUTION"
+                            ]
+                        },
+                        "description": "The function type to create or replace. Allowed values: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION."
+                    },
+                    {
+                        "name": "functionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the function to create or replace."
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The unique numeric identifier of the app owning the definition."
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "text/plain": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PublicActionFunctionIdentifier"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns the inserted or replaced function details for the specified definition, function type, and function ID."
+            },
+            "delete": {
+                "tags": [
+                    "Functions"
+                ],
+                "summary": "Archive a function for a definition",
+                "operationId": "delete-/{appId}/{definitionId}/functions/{functionType}/{functionId}_archive",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the extension definition containing the function."
+                    },
+                    {
+                        "name": "functionType",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "PRE_ACTION_EXECUTION",
+                                "PRE_FETCH_OPTIONS",
+                                "POST_FETCH_OPTIONS",
+                                "POST_ACTION_EXECUTION"
+                            ]
+                        },
+                        "description": "The execution stage of the function. Must be one of: PRE_ACTION_EXECUTION, PRE_FETCH_OPTIONS, POST_FETCH_OPTIONS, POST_ACTION_EXECUTION."
+                    },
+                    {
+                        "name": "functionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the function to delete."
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The unique numeric identifier of the app owning the definition."
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns no content upon successfully archiving the specified function from the given definition."
+            }
+        },
+        "/{appId}/{definitionId}/revisions": {
+            "get": {
+                "tags": [
+                    "Revisions"
+                ],
+                "summary": "List all definition revisions",
+                "operationId": "get-/{appId}/{definitionId}/revisions_getPage",
+                "parameters": [
+                    {
+                        "name": "definitionId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the extension definition whose revisions are retrieved."
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of results to display per page",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "description": "The paging cursor token of the last successfully read resource will be returned as the `paging.next.after` JSON property of a paged response containing more results",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "description": "The unique numeric identifier of the app owning the definition."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponsePublicActionRevisionForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ],
+                "description": "Returns a paginated list of all revisions associated with the specified automation action definition."
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "PublicActionFunction": {
+                "required": [
+                    "functionSource",
+                    "functionType"
+                ],
+                "type": "object",
+                "properties": {
+                    "functionSource": {
+                        "type": "string",
+                        "description": "The source code of the function."
+                    },
+                    "functionType": {
+                        "type": "string",
+                        "enum": [
+                            "PRE_ACTION_EXECUTION",
+                            "PRE_FETCH_OPTIONS",
+                            "POST_FETCH_OPTIONS",
+                            "POST_ACTION_EXECUTION"
+                        ],
+                        "description": "The lifecycle stage at which the function executes."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the function."
+                    }
+                },
+                "description": "Defines a serverless function associated with an automation action, including its source code and execution lifecycle type."
+            },
+            "PublicActionDefinition": {
+                "required": [
+                    "actionUrl",
+                    "functions",
+                    "id",
+                    "inputFields",
+                    "labels",
+                    "objectTypes",
+                    "published",
+                    "revisionId"
+                ],
+                "type": "object",
+                "properties": {
+                    "functions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicActionFunctionIdentifier"
+                        },
+                        "description": "List of function identifiers associated with this action."
+                    },
+                    "actionUrl": {
+                        "type": "string",
+                        "description": "The URL endpoint invoked when the action executes."
+                    },
+                    "published": {
+                        "type": "boolean",
+                        "description": "Indicates whether the action is published and available for use."
+                    },
+                    "labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/PublicActionLabels"
+                        },
+                        "description": "Localized display labels for the action, keyed by language code."
+                    },
+                    "inputFields": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/InputFieldDefinition"
+                        },
+                        "description": "List of input fields the action accepts during execution."
+                    },
+                    "outputFields": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OutputFieldDefinition"
+                        },
+                        "description": "List of output fields the action returns after execution."
+                    },
+                    "revisionId": {
+                        "type": "string",
+                        "description": "The identifier of the current revision of the action definition."
+                    },
+                    "archivedAt": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Timestamp (ms) when the action was archived, if applicable."
+                    },
+                    "inputFieldDependencies": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicActionDefinitionInputFieldDependencies"
+                        },
+                        "description": "Conditional dependencies that control input field visibility or behavior."
+                    },
+                    "executionRules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicExecutionTranslationRule"
+                        },
+                        "description": "Rules that govern how the action execution is translated or applied."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the action definition."
+                    },
+                    "objectTypes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "CRM object types this action can be applied to."
+                    },
+                    "objectRequestOptions": {
+                        "$ref": "#/components/schemas/PublicObjectRequestOptions",
+                        "description": "Options specifying which object properties to include in action requests."
+                    }
+                },
+                "description": "Defines a custom automation action, including its endpoint, input/output fields, labels, associated functions, and publication state."
+            },
+            "PublicConditionalSingleFieldDependency": {
+                "title": "CONDITIONAL_SINGLE_FIELD",
+                "required": [
+                    "controllingFieldName",
+                    "controllingFieldValue",
+                    "dependencyType",
+                    "dependentFieldNames"
+                ],
+                "type": "object",
+                "properties": {
+                    "dependencyType": {
+                        "type": "string",
+                        "default": "CONDITIONAL_SINGLE_FIELD",
+                        "enum": [
+                            "CONDITIONAL_SINGLE_FIELD"
+                        ],
+                        "description": "The type of field dependency; always CONDITIONAL_SINGLE_FIELD."
+                    },
+                    "controllingFieldName": {
+                        "type": "string",
+                        "description": "Name of the field that controls the dependency."
+                    },
+                    "controllingFieldValue": {
+                        "type": "string",
+                        "description": "The value of the controlling field that triggers the dependency."
+                    },
+                    "dependentFieldNames": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of field names dependent on the controlling field's value."
+                    }
+                },
+                "description": "Defines a conditional dependency where dependent fields are shown or hidden based on a single controlling field's value."
+            },
+            "PublicActionDefinitionInputFieldDependencies": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/PublicSingleFieldDependency",
+                        "description": "A simple single-field dependency between input fields."
+                    },
+                    {
+                        "$ref": "#/components/schemas/PublicConditionalSingleFieldDependency",
+                        "description": "A conditional single-field dependency triggered by a specific field value."
+                    }
+                ],
+                "description": "Defines a field dependency as either a single-field or conditional single-field dependency type."
+            },
+            "PublicObjectRequestOptions": {
+                "required": [
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "properties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of property names to include in the object response."
+                    }
+                },
+                "description": "Options for a public object request, specifying which properties to retrieve."
+            },
+            "ErrorDetail": {
+                "required": [
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "The status code associated with the error detail"
+                    },
+                    "in": {
+                        "type": "string",
+                        "description": "The name of the field or parameter in which the error was found"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ]
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate"
+                    }
+                },
+                "description": "Detailed error information including message, code, category, and contextual data."
+            },
+            "PublicActionLabels": {
+                "required": [
+                    "actionName"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputFieldDescriptions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of input field names to their descriptive text."
+                    },
+                    "appDisplayName": {
+                        "type": "string",
+                        "description": "Display name of the app associated with the action."
+                    },
+                    "outputFieldLabels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of output field names to their display labels."
+                    },
+                    "inputFieldOptionLabels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Nested map of input field option keys to their display labels."
+                    },
+                    "actionDescription": {
+                        "type": "string",
+                        "description": "Human-readable description of the action's purpose."
+                    },
+                    "executionRules": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of execution rule keys to their display label strings."
+                    },
+                    "inputFieldLabels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of input field names to their display labels."
+                    },
+                    "actionName": {
+                        "type": "string",
+                        "description": "Display name of the action."
+                    },
+                    "actionCardContent": {
+                        "type": "string",
+                        "description": "Text content displayed on the action's summary card."
+                    }
+                },
+                "description": "Localized display labels for an action, including field labels, descriptions, and card content."
+            },
+            "PublicSingleFieldDependency": {
+                "title": "SINGLE_FIELD",
+                "required": [
+                    "controllingFieldName",
+                    "dependencyType",
+                    "dependentFieldNames"
+                ],
+                "type": "object",
+                "properties": {
+                    "dependencyType": {
+                        "type": "string",
+                        "default": "SINGLE_FIELD",
+                        "enum": [
+                            "SINGLE_FIELD"
+                        ],
+                        "description": "The type of field dependency; always 'SINGLE_FIELD'."
+                    },
+                    "controllingFieldName": {
+                        "type": "string",
+                        "description": "The name of the field that controls the dependency."
+                    },
+                    "dependentFieldNames": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of field names dependent on the controlling field."
+                    }
+                },
+                "description": "Defines a SINGLE_FIELD dependency linking a controlling field to one or more dependent fields."
+            },
+            "ForwardPaging": {
+                "type": "object",
+                "properties": {
+                    "next": {
+                        "$ref": "#/components/schemas/NextPage",
+                        "description": "Cursor and link information for retrieving the next page."
+                    }
+                },
+                "description": "Pagination wrapper containing a reference to the next page of results."
+            },
+            "FieldTypeDefinition": {
+                "required": [
+                    "externalOptions",
+                    "name",
+                    "options",
+                    "type"
+                ],
+                "type": "object",
+                "properties": {
+                    "helpText": {
+                        "type": "string",
+                        "description": "Supplementary help text displayed alongside the field."
+                    },
+                    "referencedObjectType": {
+                        "type": "string",
+                        "enum": [
+                            "CONTACT",
+                            "COMPANY",
+                            "DEAL",
+                            "ENGAGEMENT",
+                            "TICKET",
+                            "OWNER",
+                            "PRODUCT",
+                            "LINE_ITEM",
+                            "BET_DELIVERABLE_SERVICE",
+                            "CONTENT",
+                            "CONVERSATION",
+                            "BET_ALERT",
+                            "PORTAL",
+                            "QUOTE",
+                            "FORM_SUBMISSION_INBOUNDDB",
+                            "QUOTA",
+                            "UNSUBSCRIBE",
+                            "COMMUNICATION",
+                            "FEEDBACK_SUBMISSION",
+                            "ATTRIBUTION",
+                            "SALESFORCE_SYNC_ERROR",
+                            "RESTORABLE_CRM_OBJECT",
+                            "HUB",
+                            "LANDING_PAGE",
+                            "PRODUCT_OR_FOLDER",
+                            "TASK",
+                            "FORM",
+                            "MARKETING_EMAIL",
+                            "AD_ACCOUNT",
+                            "AD_CAMPAIGN",
+                            "AD_GROUP",
+                            "AD",
+                            "KEYWORD",
+                            "CAMPAIGN",
+                            "SOCIAL_CHANNEL",
+                            "SOCIAL_POST",
+                            "SITE_PAGE",
+                            "BLOG_POST",
+                            "IMPORT",
+                            "EXPORT",
+                            "CTA",
+                            "TASK_TEMPLATE",
+                            "AUTOMATION_PLATFORM_FLOW",
+                            "OBJECT_LIST",
+                            "NOTE",
+                            "MEETING_EVENT",
+                            "CALL",
+                            "EMAIL",
+                            "PUBLISHING_TASK",
+                            "CONVERSATION_SESSION",
+                            "CONTACT_CREATE_ATTRIBUTION",
+                            "INVOICE",
+                            "MARKETING_EVENT",
+                            "CONVERSATION_INBOX",
+                            "CHATFLOW",
+                            "MEDIA_BRIDGE",
+                            "SEQUENCE",
+                            "SEQUENCE_STEP",
+                            "FORECAST",
+                            "SNIPPET",
+                            "TEMPLATE",
+                            "DEAL_CREATE_ATTRIBUTION",
+                            "QUOTE_TEMPLATE",
+                            "QUOTE_MODULE",
+                            "QUOTE_MODULE_FIELD",
+                            "QUOTE_FIELD",
+                            "SEQUENCE_ENROLLMENT",
+                            "SUBSCRIPTION",
+                            "ACCEPTANCE_TEST",
+                            "SOCIAL_BROADCAST",
+                            "DEAL_SPLIT",
+                            "DEAL_REGISTRATION",
+                            "GOAL_TARGET",
+                            "GOAL_TARGET_GROUP",
+                            "PORTAL_OBJECT_SYNC_MESSAGE",
+                            "FILE_MANAGER_FILE",
+                            "FILE_MANAGER_FOLDER",
+                            "SEQUENCE_STEP_ENROLLMENT",
+                            "APPROVAL",
+                            "APPROVAL_STEP",
+                            "CTA_VARIANT",
+                            "SALES_DOCUMENT",
+                            "DISCOUNT",
+                            "FEE",
+                            "TAX",
+                            "MARKETING_CALENDAR",
+                            "PERMISSIONS_TESTING",
+                            "PRIVACY_SCANNER_COOKIE",
+                            "DATA_SYNC_STATE",
+                            "WEB_INTERACTIVE",
+                            "PLAYBOOK",
+                            "FOLDER",
+                            "PLAYBOOK_QUESTION",
+                            "PLAYBOOK_SUBMISSION",
+                            "PLAYBOOK_SUBMISSION_ANSWER",
+                            "COMMERCE_PAYMENT",
+                            "GSC_PROPERTY",
+                            "SOX_PROTECTED_DUMMY_TYPE",
+                            "BLOG_LISTING_PAGE",
+                            "QUARANTINED_SUBMISSION",
+                            "PAYMENT_SCHEDULE",
+                            "PAYMENT_SCHEDULE_INSTALLMENT",
+                            "MARKETING_CAMPAIGN_UTM",
+                            "DISCOUNT_TEMPLATE",
+                            "DISCOUNT_CODE",
+                            "FEEDBACK_SURVEY",
+                            "CMS_URL",
+                            "SALES_TASK",
+                            "SALES_WORKLOAD",
+                            "USER",
+                            "POSTAL_MAIL",
+                            "SCHEMAS_BACKEND_TEST",
+                            "PAYMENT_LINK",
+                            "SUBMISSION_TAG",
+                            "CAMPAIGN_STEP",
+                            "SCHEDULING_PAGE",
+                            "SOX_PROTECTED_TEST_TYPE",
+                            "ORDER",
+                            "MARKETING_SMS",
+                            "PARTNER_ACCOUNT",
+                            "CAMPAIGN_TEMPLATE",
+                            "CAMPAIGN_TEMPLATE_STEP",
+                            "PLAYLIST",
+                            "CLIP",
+                            "CAMPAIGN_BUDGET_ITEM",
+                            "CAMPAIGN_SPEND_ITEM",
+                            "MIC",
+                            "CONTENT_AUDIT",
+                            "CONTENT_AUDIT_PAGE",
+                            "PLAYLIST_FOLDER",
+                            "LEAD",
+                            "ABANDONED_CART",
+                            "EXTERNAL_WEB_URL",
+                            "VIEW",
+                            "VIEW_BLOCK",
+                            "ROSTER",
+                            "CART",
+                            "AUTOMATION_PLATFORM_FLOW_ACTION",
+                            "SOCIAL_PROFILE",
+                            "PARTNER_CLIENT",
+                            "ROSTER_MEMBER",
+                            "MARKETING_EVENT_ATTENDANCE",
+                            "ALL_PAGES",
+                            "AI_FORECAST",
+                            "CRM_PIPELINES_DUMMY_TYPE",
+                            "KNOWLEDGE_ARTICLE",
+                            "PROPERTY_INFO",
+                            "DATA_PRIVACY_CONSENT",
+                            "GOAL_TEMPLATE",
+                            "SCORE_CONFIGURATION",
+                            "AUDIENCE",
+                            "PARTNER_CLIENT_REVENUE",
+                            "AUTOMATION_JOURNEY",
+                            "UNKNOWN"
+                        ],
+                        "description": "The HubSpot object type this field references."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The internal name identifier of the field type."
+                    },
+                    "options": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Option"
+                        },
+                        "description": "List of selectable options available for the field."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A human-readable description of the field type."
+                    },
+                    "externalOptionsReferenceType": {
+                        "type": "string",
+                        "description": "Reference type used to resolve externally sourced options."
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "The display label shown to users for the field."
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "string",
+                            "number",
+                            "bool",
+                            "datetime",
+                            "enumeration",
+                            "date",
+                            "phone_number",
+                            "currency_number",
+                            "json",
+                            "object_coordinates"
+                        ],
+                        "description": "The data type of the field value (e.g., string, number, bool)."
+                    },
+                    "fieldType": {
+                        "type": "string",
+                        "enum": [
+                            "booleancheckbox",
+                            "checkbox",
+                            "date",
+                            "file",
+                            "number",
+                            "phonenumber",
+                            "radio",
+                            "select",
+                            "text",
+                            "textarea",
+                            "calculation_equation",
+                            "calculation_rollup",
+                            "calculation_score",
+                            "calculation_read_time",
+                            "unknown",
+                            "html"
+                        ],
+                        "description": "The UI control type used to render the field."
+                    },
+                    "optionsUrl": {
+                        "type": "string",
+                        "description": "URL endpoint for fetching field options dynamically."
+                    },
+                    "externalOptions": {
+                        "type": "boolean",
+                        "description": "Indicates whether options are loaded from an external source."
+                    }
+                },
+                "description": "Defines the type, display, and option configuration for an action input field."
+            },
+            "CollectionResponsePublicActionFunctionIdentifierNoPaging": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicActionFunctionIdentifier"
+                        },
+                        "description": "List of action function identifiers in the response."
+                    }
+                },
+                "description": "A collection of action function identifiers returned without paging."
+            },
+            "InputFieldDefinition": {
+                "required": [
+                    "isRequired",
+                    "typeDefinition"
+                ],
+                "type": "object",
+                "properties": {
+                    "isRequired": {
+                        "type": "boolean",
+                        "description": "Indicates whether the input field is required."
+                    },
+                    "automationFieldType": {
+                        "type": "string",
+                        "description": "The automation-specific field type identifier."
+                    },
+                    "typeDefinition": {
+                        "$ref": "#/components/schemas/FieldTypeDefinition",
+                        "description": "The type definition details for this input field."
+                    },
+                    "supportedValueTypes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "STATIC_VALUE",
+                                "OBJECT_PROPERTY",
+                                "FIELD_DATA",
+                                "FETCHED_OBJECT_PROPERTY",
+                                "ENROLLMENT_EVENT_PROPERTY"
+                            ]
+                        },
+                        "description": "List of value types accepted by this input field."
+                    }
+                },
+                "description": "Defines an input field for an action, including its type and accepted value sources."
+            },
+            "PublicExecutionTranslationRule": {
+                "required": [
+                    "conditions",
+                    "labelName"
+                ],
+                "type": "object",
+                "properties": {
+                    "labelName": {
+                        "type": "string",
+                        "description": "The display label name for this translation rule."
+                    },
+                    "conditions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {}
+                        },
+                        "description": "Key-value map of conditions that trigger this translation rule."
+                    }
+                },
+                "description": "Defines a translation rule mapping execution conditions to a display label."
+            },
+            "PublicActionFunctionIdentifier": {
+                "required": [
+                    "functionType"
+                ],
+                "type": "object",
+                "properties": {
+                    "functionType": {
+                        "type": "string",
+                        "enum": [
+                            "PRE_ACTION_EXECUTION",
+                            "PRE_FETCH_OPTIONS",
+                            "POST_FETCH_OPTIONS",
+                            "POST_ACTION_EXECUTION"
+                        ],
+                        "description": "The execution stage at which this function is invoked."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the action function."
+                    }
+                },
+                "description": "Identifies a function associated with a public action by type and optional ID."
+            },
+            "PublicActionRevision": {
+                "required": [
+                    "createdAt",
+                    "definition",
+                    "id",
+                    "revisionId"
+                ],
+                "type": "object",
+                "properties": {
+                    "revisionId": {
+                        "type": "string",
+                        "description": "The unique identifier for this action revision."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The timestamp when this revision was created."
+                    },
+                    "definition": {
+                        "$ref": "#/components/schemas/PublicActionDefinition",
+                        "description": "The full action definition associated with this revision."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the action revision record."
+                    }
+                },
+                "description": "Represents a versioned revision of a public action definition."
+            },
+            "CallbackCompletionRequest": {
+                "required": [
+                    "outputFields"
+                ],
+                "type": "object",
+                "properties": {
+                    "outputFields": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "description": "Request payload for completing an action callback with output field values."
+            },
+            "CollectionResponsePublicActionDefinitionForwardPaging": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "paging": {
+                        "$ref": "#/components/schemas/ForwardPaging",
+                        "description": "Forward paging metadata for retrieving the next result set."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicActionDefinition"
+                        },
+                        "description": "The list of returned public action definitions."
+                    }
+                },
+                "description": "A paginated collection of public action definitions with forward paging support."
+            },
+            "Error": {
+                "required": [
+                    "category",
+                    "correlationId",
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ],
+                            "invalidPropertyName": [
+                                "propertyValue"
+                            ]
+                        }
+                    },
+                    "correlationId": {
+                        "type": "string",
+                        "description": "A unique identifier for the request. Include this value with any error reports or support tickets",
+                        "format": "uuid",
+                        "example": "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of link names to associated URIs containing documentation about the error or recommended remediation steps",
+                        "example": {
+                            "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate",
+                        "example": "Invalid input (details will vary based on the error)"
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "The error category",
+                        "example": "VALIDATION_ERROR"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "description": "further information about the error",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        }
+                    }
+                },
+                "example": {
+                    "message": "Invalid input (details will vary based on the error)",
+                    "correlationId": "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+                    "category": "VALIDATION_ERROR",
+                    "links": {
+                        "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                    }
+                },
+                "description": "Standard error response object containing details about a failed request"
+            },
+            "CollectionResponsePublicActionRevisionForwardPaging": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "paging": {
+                        "$ref": "#/components/schemas/ForwardPaging",
+                        "description": "Forward paging cursor for retrieving the next results page"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicActionRevision"
+                        },
+                        "description": "Array of public action revision objects returned in this page"
+                    }
+                },
+                "description": "Paginated collection of public action revision records"
+            },
+            "PublicActionDefinitionEggInputFieldDependencies": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/PublicSingleFieldDependency",
+                        "description": "A simple single-field dependency between input fields"
+                    },
+                    {
+                        "$ref": "#/components/schemas/PublicConditionalSingleFieldDependency",
+                        "description": "A conditional single-field dependency between input fields"
+                    }
+                ],
+                "description": "Input field dependency definition; either a single or conditional single field dependency"
+            },
+            "CallbackCompletionBatchRequest": {
+                "required": [
+                    "callbackId",
+                    "outputFields"
+                ],
+                "type": "object",
+                "properties": {
+                    "outputFields": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Key-value map of output field names to their resolved string values"
+                    },
+                    "callbackId": {
+                        "type": "string",
+                        "description": "Unique identifier of the callback to complete"
+                    }
+                },
+                "description": "Request payload for completing a batch callback with output field values"
+            },
+            "PublicActionDefinitionEgg": {
+                "required": [
+                    "actionUrl",
+                    "functions",
+                    "inputFields",
+                    "labels",
+                    "objectTypes",
+                    "published"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputFields": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/InputFieldDefinition"
+                        },
+                        "description": "Array of input field definitions accepted by this action"
+                    },
+                    "outputFields": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OutputFieldDefinition"
+                        },
+                        "description": "Array of output field definitions produced by this action"
+                    },
+                    "archivedAt": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Timestamp (ms) indicating when the action definition was archived"
+                    },
+                    "functions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicActionFunction"
+                        },
+                        "description": "Array of serverless functions associated with this action"
+                    },
+                    "actionUrl": {
+                        "type": "string",
+                        "description": "Endpoint URL invoked when this action executes"
+                    },
+                    "inputFieldDependencies": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicActionDefinitionEggInputFieldDependencies"
+                        },
+                        "description": "Array of dependency rules governing input field visibility or behavior"
+                    },
+                    "published": {
+                        "type": "boolean",
+                        "description": "Indicates whether this action definition is publicly published"
+                    },
+                    "executionRules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicExecutionTranslationRule"
+                        },
+                        "description": "Array of rules controlling when and how this action executes"
+                    },
+                    "objectTypes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "CRM object types this action is applicable to"
+                    },
+                    "objectRequestOptions": {
+                        "$ref": "#/components/schemas/PublicObjectRequestOptions",
+                        "description": "Options specifying which object properties to fetch at execution time."
+                    },
+                    "labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/PublicActionLabels"
+                        },
+                        "description": "Localized display labels for the action, keyed by language code."
+                    }
+                },
+                "description": "Request payload for creating a new custom automation action definition"
+            },
+            "PublicActionDefinitionPatch": {
+                "type": "object",
+                "properties": {
+                    "inputFields": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/InputFieldDefinition"
+                        },
+                        "description": "Updated list of input field definitions for the action."
+                    },
+                    "outputFields": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OutputFieldDefinition"
+                        },
+                        "description": "Updated list of output field definitions returned by the action."
+                    },
+                    "actionUrl": {
+                        "type": "string",
+                        "description": "The URL endpoint invoked when the action executes."
+                    },
+                    "inputFieldDependencies": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicActionDefinitionPatchInputFieldDependencies"
+                        },
+                        "description": "Conditional dependencies controlling input field visibility or behavior."
+                    },
+                    "published": {
+                        "type": "boolean",
+                        "description": "Whether the action is published and available for use in workflows."
+                    },
+                    "executionRules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicExecutionTranslationRule"
+                        },
+                        "description": "Rules that govern how and when the action execution is translated."
+                    },
+                    "objectTypes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "CRM object types this action is applicable to."
+                    },
+                    "objectRequestOptions": {
+                        "$ref": "#/components/schemas/PublicObjectRequestOptions",
+                        "description": "Options specifying which object properties to fetch at execution time."
+                    },
+                    "labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/PublicActionLabels"
+                        },
+                        "description": "Localized display labels for the action, keyed by language code."
+                    }
+                },
+                "description": "Partial update payload for modifying an existing custom action definition."
+            },
+            "BatchInputCallbackCompletionBatchRequest": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CallbackCompletionBatchRequest"
+                        },
+                        "description": "Array of individual callback completion requests in the batch."
+                    }
+                },
+                "description": "A batch of callback completion requests to resolve multiple pending action callbacks."
+            },
+            "PublicActionDefinitionPatchInputFieldDependencies": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/PublicSingleFieldDependency",
+                        "description": "A simple dependency based on a single controlling input field."
+                    },
+                    {
+                        "$ref": "#/components/schemas/PublicConditionalSingleFieldDependency",
+                        "description": "A conditional dependency driven by a single input field's value."
+                    }
+                ],
+                "description": "A field dependency rule; either a single-field or conditional single-field dependency."
+            },
+            "Option": {
+                "required": [
+                    "description",
+                    "displayOrder",
+                    "doubleData",
+                    "hidden",
+                    "label",
+                    "readOnly",
+                    "value"
+                ],
+                "type": "object",
+                "properties": {
+                    "hidden": {
+                        "type": "boolean",
+                        "description": "Whether this option is hidden from the user interface."
+                    },
+                    "displayOrder": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Numeric order in which the option appears in the UI."
+                    },
+                    "doubleData": {
+                        "type": "number",
+                        "description": "Numeric double value associated with the option."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable description of the option."
+                    },
+                    "readOnly": {
+                        "type": "boolean",
+                        "description": "Indicates whether the option is read-only."
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "Display label shown to users for the option."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "Stored string value representing the option."
+                    }
+                },
+                "description": "A selectable option for an input field, including its label, value, and display metadata."
+            },
+            "OutputFieldDefinition": {
+                "required": [
+                    "typeDefinition"
+                ],
+                "type": "object",
+                "properties": {
+                    "typeDefinition": {
+                        "$ref": "#/components/schemas/FieldTypeDefinition",
+                        "description": "The type definition describing the output field's data type and structure."
+                    }
+                },
+                "description": "Defines an output field, including its type definition for an automation action."
+            },
+            "NextPage": {
+                "required": [
+                    "after"
+                ],
+                "type": "object",
+                "properties": {
+                    "link": {
+                        "type": "string",
+                        "description": "URL link to the next page of results."
+                    },
+                    "after": {
+                        "type": "string",
+                        "description": "Cursor token used to fetch the next page of results."
+                    }
+                },
+                "description": "Pagination cursor object used to retrieve the next page of results."
+            }
+        },
+        "responses": {
+            "Error": {
+                "description": "An error occurred.",
+                "content": {
+                    "*/*": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "oauth2_legacy": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
+                        "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
+                        "scopes": {
+                            "automation": "Read from and write to my Workflows"
+                        }
+                    }
+                }
+            },
+            "developer_hapikey": {
+                "type": "apiKey",
+                "name": "hapikey",
+                "in": "query"
+            },
+            "private_apps_legacy": {
+                "type": "apiKey",
+                "name": "private-app-legacy",
+                "in": "header",
+                "x-ballerina-name": "privateAppLegacy"
+            }
+        }
+    },
+    "x-hubspot-available-client-libraries": [
+        "PHP",
+        "Node",
+        "Ruby",
+        "Python"
+    ],
+    "x-hubspot-product-tier-requirements": {
+        "marketing": "PROFESSIONAL",
+        "sales": "PROFESSIONAL",
+        "service": "PROFESSIONAL"
+    },
+    "x-hubspot-documentation-banner": "NONE"
+}

--- a/docs/spec/flattened_openapi.json
+++ b/docs/spec/flattened_openapi.json
@@ -1,0 +1,1610 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Automation Actions V4",
+    "version" : "v4",
+    "x-hubspot-product-tier-requirements" : {
+      "marketing" : "PROFESSIONAL",
+      "sales" : "PROFESSIONAL",
+      "service" : "PROFESSIONAL"
+    },
+    "x-hubspot-documentation-banner" : "NONE",
+    "x-hubspot-api-use-case" : "You want to empower other users in your account to automate specialized parts of their day-to-day processes (e.g., creating highly customized quotes based on the data from an enrolled contact and their associations).",
+    "x-hubspot-related-documentation" : [ {
+      "name" : "Custom Workflow Actions Guide",
+      "url" : "https://developers.hubspot.com/beta-docs/guides/api/automation/custom-workflow-actions"
+    } ],
+    "x-hubspot-introduction" : "Use the automation API to define custom actions in the HubSpot workflows tool, which allows users in your account to integrate with external services as they build out a HubSpot workflow."
+  },
+  "servers" : [ {
+    "url" : "https://api.hubapi.com/automation/v4/actions"
+  } ],
+  "tags" : [ {
+    "name" : "Callbacks"
+  }, {
+    "name" : "Definitions"
+  }, {
+    "name" : "Functions"
+  }, {
+    "name" : "Revisions"
+  } ],
+  "paths" : {
+    "/callbacks/{callbackId}/complete" : {
+      "post" : {
+        "tags" : [ "Callbacks" ],
+        "summary" : "Completes a single callback",
+        "operationId" : "post-/callbacks/{callbackId}/complete_complete",
+        "parameters" : [ {
+          "name" : "callbackId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CallbackCompletionRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "automation" ]
+        }, {
+          "private_apps_legacy" : [ "automation" ]
+        } ]
+      }
+    },
+    "/callbacks/complete" : {
+      "post" : {
+        "tags" : [ "Callbacks" ],
+        "summary" : "Completes a batch of callbacks",
+        "operationId" : "post-/callbacks/complete_completeBatch",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputCallbackCompletionBatchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "automation" ]
+        }, {
+          "private_apps_legacy" : [ "automation" ]
+        } ]
+      }
+    },
+    "/{appId}" : {
+      "get" : {
+        "tags" : [ "Definitions" ],
+        "summary" : "Get paged extension definitions",
+        "operationId" : "get-/{appId}_getPage",
+        "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The maximum number of results to display per page",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "after",
+          "in" : "query",
+          "description" : "The paging cursor token of the last successfully read resource will be returned as the `paging.next.after` JSON property of a paged response containing more results",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponsePublicActionDefinitionForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      },
+      "post" : {
+        "tags" : [ "Definitions" ],
+        "summary" : "Create a new extension definition",
+        "operationId" : "post-/{appId}_create",
+        "parameters" : [ {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PublicActionDefinitionEgg"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PublicActionDefinition"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      }
+    },
+    "/{appId}/{definitionId}/functions" : {
+      "get" : {
+        "tags" : [ "Functions" ],
+        "summary" : "Get all functions for a given definition",
+        "operationId" : "get-/{appId}/{definitionId}/functions_getPage",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponsePublicActionFunctionIdentifierNoPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      }
+    },
+    "/{appId}/{definitionId}/functions/{functionType}" : {
+      "get" : {
+        "tags" : [ "Functions" ],
+        "summary" : "Get all functions by a type for a given definition",
+        "operationId" : "get-/{appId}/{definitionId}/functions/{functionType}_getByFunctionType",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "functionType",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "PRE_ACTION_EXECUTION", "PRE_FETCH_OPTIONS", "POST_FETCH_OPTIONS", "POST_ACTION_EXECUTION" ]
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PublicActionFunction"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      },
+      "put" : {
+        "tags" : [ "Functions" ],
+        "summary" : "Insert a function for a definition",
+        "operationId" : "put-/{appId}/{definitionId}/functions/{functionType}_createOrReplaceByFunctionType",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "functionType",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "PRE_ACTION_EXECUTION", "PRE_FETCH_OPTIONS", "POST_FETCH_OPTIONS", "POST_ACTION_EXECUTION" ]
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PublicActionFunctionIdentifier"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "Functions" ],
+        "summary" : "Delete a function for a definition",
+        "operationId" : "delete-/{appId}/{definitionId}/functions/{functionType}_archiveByFunctionType",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "functionType",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "PRE_ACTION_EXECUTION", "PRE_FETCH_OPTIONS", "POST_FETCH_OPTIONS", "POST_ACTION_EXECUTION" ]
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      }
+    },
+    "/{appId}/{definitionId}/revisions/{revisionId}" : {
+      "get" : {
+        "tags" : [ "Revisions" ],
+        "summary" : "Gets a revision for a given definition by revision id",
+        "operationId" : "get-/{appId}/{definitionId}/revisions/{revisionId}_getById",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "revisionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PublicActionRevision"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      }
+    },
+    "/{appId}/{definitionId}" : {
+      "get" : {
+        "tags" : [ "Definitions" ],
+        "summary" : "Get extension definition by Id",
+        "operationId" : "get-/{appId}/{definitionId}_getById",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PublicActionDefinition"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "Definitions" ],
+        "summary" : "Archive an extension definition",
+        "operationId" : "delete-/{appId}/{definitionId}_archive",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      },
+      "patch" : {
+        "tags" : [ "Definitions" ],
+        "summary" : "Patch an existing extension definition",
+        "operationId" : "patch-/{appId}/{definitionId}_update",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PublicActionDefinitionPatch"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PublicActionDefinition"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      }
+    },
+    "/{appId}/{definitionId}/functions/{functionType}/{functionId}" : {
+      "get" : {
+        "tags" : [ "Functions" ],
+        "summary" : "Get a function for a given definition",
+        "operationId" : "get-/{appId}/{definitionId}/functions/{functionType}/{functionId}_getById",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "functionType",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "PRE_ACTION_EXECUTION", "PRE_FETCH_OPTIONS", "POST_FETCH_OPTIONS", "POST_ACTION_EXECUTION" ]
+          }
+        }, {
+          "name" : "functionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PublicActionFunction"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      },
+      "put" : {
+        "tags" : [ "Functions" ],
+        "summary" : "Insert a function for a definition",
+        "operationId" : "put-/{appId}/{definitionId}/functions/{functionType}/{functionId}_createOrReplace",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "functionType",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "PRE_ACTION_EXECUTION", "PRE_FETCH_OPTIONS", "POST_FETCH_OPTIONS", "POST_ACTION_EXECUTION" ]
+          }
+        }, {
+          "name" : "functionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PublicActionFunctionIdentifier"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "Functions" ],
+        "summary" : "Archive a function for a definition",
+        "operationId" : "delete-/{appId}/{definitionId}/functions/{functionType}/{functionId}_archive",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "functionType",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "PRE_ACTION_EXECUTION", "PRE_FETCH_OPTIONS", "POST_FETCH_OPTIONS", "POST_ACTION_EXECUTION" ]
+          }
+        }, {
+          "name" : "functionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      }
+    },
+    "/{appId}/{definitionId}/revisions" : {
+      "get" : {
+        "tags" : [ "Revisions" ],
+        "summary" : "Get all revisions for a given definition",
+        "operationId" : "get-/{appId}/{definitionId}/revisions_getPage",
+        "parameters" : [ {
+          "name" : "definitionId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The maximum number of results to display per page",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "after",
+          "in" : "query",
+          "description" : "The paging cursor token of the last successfully read resource will be returned as the `paging.next.after` JSON property of a paged response containing more results",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponsePublicActionRevisionForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "PublicActionFunction" : {
+        "required" : [ "functionSource", "functionType" ],
+        "type" : "object",
+        "properties" : {
+          "functionSource" : {
+            "type" : "string"
+          },
+          "functionType" : {
+            "type" : "string",
+            "enum" : [ "PRE_ACTION_EXECUTION", "PRE_FETCH_OPTIONS", "POST_FETCH_OPTIONS", "POST_ACTION_EXECUTION" ]
+          },
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PublicActionDefinition" : {
+        "required" : [ "actionUrl", "functions", "id", "inputFields", "labels", "objectTypes", "published", "revisionId" ],
+        "type" : "object",
+        "properties" : {
+          "functions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicActionFunctionIdentifier"
+            }
+          },
+          "actionUrl" : {
+            "type" : "string"
+          },
+          "published" : {
+            "type" : "boolean"
+          },
+          "labels" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/PublicActionLabels"
+            }
+          },
+          "inputFields" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/InputFieldDefinition"
+            }
+          },
+          "outputFields" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OutputFieldDefinition"
+            }
+          },
+          "revisionId" : {
+            "type" : "string"
+          },
+          "archivedAt" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "inputFieldDependencies" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicActionDefinitionInputFieldDependencies"
+            }
+          },
+          "executionRules" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicExecutionTranslationRule"
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "objectTypes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "objectRequestOptions" : {
+            "$ref" : "#/components/schemas/PublicObjectRequestOptions"
+          }
+        }
+      },
+      "PublicConditionalSingleFieldDependency" : {
+        "title" : "CONDITIONAL_SINGLE_FIELD",
+        "required" : [ "controllingFieldName", "controllingFieldValue", "dependencyType", "dependentFieldNames" ],
+        "type" : "object",
+        "properties" : {
+          "dependencyType" : {
+            "type" : "string",
+            "enum" : [ "CONDITIONAL_SINGLE_FIELD" ],
+            "default" : "CONDITIONAL_SINGLE_FIELD"
+          },
+          "controllingFieldName" : {
+            "type" : "string"
+          },
+          "controllingFieldValue" : {
+            "type" : "string"
+          },
+          "dependentFieldNames" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "PublicActionDefinitionInputFieldDependencies" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/PublicSingleFieldDependency"
+        }, {
+          "$ref" : "#/components/schemas/PublicConditionalSingleFieldDependency"
+        } ]
+      },
+      "PublicObjectRequestOptions" : {
+        "required" : [ "properties" ],
+        "type" : "object",
+        "properties" : {
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "ErrorDetail" : {
+        "required" : [ "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "code" : {
+            "type" : "string",
+            "description" : "The status code associated with the error detail"
+          },
+          "in" : {
+            "type" : "string",
+            "description" : "The name of the field or parameter in which the error was found"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ]
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate"
+          }
+        }
+      },
+      "PublicActionLabels" : {
+        "required" : [ "actionName" ],
+        "type" : "object",
+        "properties" : {
+          "inputFieldDescriptions" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "appDisplayName" : {
+            "type" : "string"
+          },
+          "outputFieldLabels" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "inputFieldOptionLabels" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "string"
+              }
+            }
+          },
+          "actionDescription" : {
+            "type" : "string"
+          },
+          "executionRules" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "inputFieldLabels" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "actionName" : {
+            "type" : "string"
+          },
+          "actionCardContent" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PublicSingleFieldDependency" : {
+        "title" : "SINGLE_FIELD",
+        "required" : [ "controllingFieldName", "dependencyType", "dependentFieldNames" ],
+        "type" : "object",
+        "properties" : {
+          "dependencyType" : {
+            "type" : "string",
+            "enum" : [ "SINGLE_FIELD" ],
+            "default" : "SINGLE_FIELD"
+          },
+          "controllingFieldName" : {
+            "type" : "string"
+          },
+          "dependentFieldNames" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "ForwardPaging" : {
+        "type" : "object",
+        "properties" : {
+          "next" : {
+            "$ref" : "#/components/schemas/NextPage"
+          }
+        }
+      },
+      "FieldTypeDefinition" : {
+        "required" : [ "externalOptions", "name", "options", "type" ],
+        "type" : "object",
+        "properties" : {
+          "helpText" : {
+            "type" : "string"
+          },
+          "referencedObjectType" : {
+            "type" : "string",
+            "enum" : [ "CONTACT", "COMPANY", "DEAL", "ENGAGEMENT", "TICKET", "OWNER", "PRODUCT", "LINE_ITEM", "BET_DELIVERABLE_SERVICE", "CONTENT", "CONVERSATION", "BET_ALERT", "PORTAL", "QUOTE", "FORM_SUBMISSION_INBOUNDDB", "QUOTA", "UNSUBSCRIBE", "COMMUNICATION", "FEEDBACK_SUBMISSION", "ATTRIBUTION", "SALESFORCE_SYNC_ERROR", "RESTORABLE_CRM_OBJECT", "HUB", "LANDING_PAGE", "PRODUCT_OR_FOLDER", "TASK", "FORM", "MARKETING_EMAIL", "AD_ACCOUNT", "AD_CAMPAIGN", "AD_GROUP", "AD", "KEYWORD", "CAMPAIGN", "SOCIAL_CHANNEL", "SOCIAL_POST", "SITE_PAGE", "BLOG_POST", "IMPORT", "EXPORT", "CTA", "TASK_TEMPLATE", "AUTOMATION_PLATFORM_FLOW", "OBJECT_LIST", "NOTE", "MEETING_EVENT", "CALL", "EMAIL", "PUBLISHING_TASK", "CONVERSATION_SESSION", "CONTACT_CREATE_ATTRIBUTION", "INVOICE", "MARKETING_EVENT", "CONVERSATION_INBOX", "CHATFLOW", "MEDIA_BRIDGE", "SEQUENCE", "SEQUENCE_STEP", "FORECAST", "SNIPPET", "TEMPLATE", "DEAL_CREATE_ATTRIBUTION", "QUOTE_TEMPLATE", "QUOTE_MODULE", "QUOTE_MODULE_FIELD", "QUOTE_FIELD", "SEQUENCE_ENROLLMENT", "SUBSCRIPTION", "ACCEPTANCE_TEST", "SOCIAL_BROADCAST", "DEAL_SPLIT", "DEAL_REGISTRATION", "GOAL_TARGET", "GOAL_TARGET_GROUP", "PORTAL_OBJECT_SYNC_MESSAGE", "FILE_MANAGER_FILE", "FILE_MANAGER_FOLDER", "SEQUENCE_STEP_ENROLLMENT", "APPROVAL", "APPROVAL_STEP", "CTA_VARIANT", "SALES_DOCUMENT", "DISCOUNT", "FEE", "TAX", "MARKETING_CALENDAR", "PERMISSIONS_TESTING", "PRIVACY_SCANNER_COOKIE", "DATA_SYNC_STATE", "WEB_INTERACTIVE", "PLAYBOOK", "FOLDER", "PLAYBOOK_QUESTION", "PLAYBOOK_SUBMISSION", "PLAYBOOK_SUBMISSION_ANSWER", "COMMERCE_PAYMENT", "GSC_PROPERTY", "SOX_PROTECTED_DUMMY_TYPE", "BLOG_LISTING_PAGE", "QUARANTINED_SUBMISSION", "PAYMENT_SCHEDULE", "PAYMENT_SCHEDULE_INSTALLMENT", "MARKETING_CAMPAIGN_UTM", "DISCOUNT_TEMPLATE", "DISCOUNT_CODE", "FEEDBACK_SURVEY", "CMS_URL", "SALES_TASK", "SALES_WORKLOAD", "USER", "POSTAL_MAIL", "SCHEMAS_BACKEND_TEST", "PAYMENT_LINK", "SUBMISSION_TAG", "CAMPAIGN_STEP", "SCHEDULING_PAGE", "SOX_PROTECTED_TEST_TYPE", "ORDER", "MARKETING_SMS", "PARTNER_ACCOUNT", "CAMPAIGN_TEMPLATE", "CAMPAIGN_TEMPLATE_STEP", "PLAYLIST", "CLIP", "CAMPAIGN_BUDGET_ITEM", "CAMPAIGN_SPEND_ITEM", "MIC", "CONTENT_AUDIT", "CONTENT_AUDIT_PAGE", "PLAYLIST_FOLDER", "LEAD", "ABANDONED_CART", "EXTERNAL_WEB_URL", "VIEW", "VIEW_BLOCK", "ROSTER", "CART", "AUTOMATION_PLATFORM_FLOW_ACTION", "SOCIAL_PROFILE", "PARTNER_CLIENT", "ROSTER_MEMBER", "MARKETING_EVENT_ATTENDANCE", "ALL_PAGES", "AI_FORECAST", "CRM_PIPELINES_DUMMY_TYPE", "KNOWLEDGE_ARTICLE", "PROPERTY_INFO", "DATA_PRIVACY_CONSENT", "GOAL_TEMPLATE", "SCORE_CONFIGURATION", "AUDIENCE", "PARTNER_CLIENT_REVENUE", "AUTOMATION_JOURNEY", "UNKNOWN" ]
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "options" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Option"
+            }
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "externalOptionsReferenceType" : {
+            "type" : "string"
+          },
+          "label" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "string", "number", "bool", "datetime", "enumeration", "date", "phone_number", "currency_number", "json", "object_coordinates" ]
+          },
+          "fieldType" : {
+            "type" : "string",
+            "enum" : [ "booleancheckbox", "checkbox", "date", "file", "number", "phonenumber", "radio", "select", "text", "textarea", "calculation_equation", "calculation_rollup", "calculation_score", "calculation_read_time", "unknown", "html" ]
+          },
+          "optionsUrl" : {
+            "type" : "string"
+          },
+          "externalOptions" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "CollectionResponsePublicActionFunctionIdentifierNoPaging" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicActionFunctionIdentifier"
+            }
+          }
+        }
+      },
+      "InputFieldDefinition" : {
+        "required" : [ "isRequired", "typeDefinition" ],
+        "type" : "object",
+        "properties" : {
+          "isRequired" : {
+            "type" : "boolean"
+          },
+          "automationFieldType" : {
+            "type" : "string"
+          },
+          "typeDefinition" : {
+            "$ref" : "#/components/schemas/FieldTypeDefinition"
+          },
+          "supportedValueTypes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "STATIC_VALUE", "OBJECT_PROPERTY", "FIELD_DATA", "FETCHED_OBJECT_PROPERTY", "ENROLLMENT_EVENT_PROPERTY" ]
+            }
+          }
+        }
+      },
+      "PublicExecutionTranslationRule" : {
+        "required" : [ "conditions", "labelName" ],
+        "type" : "object",
+        "properties" : {
+          "labelName" : {
+            "type" : "string"
+          },
+          "conditions" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "object",
+              "properties" : { }
+            }
+          }
+        }
+      },
+      "PublicActionFunctionIdentifier" : {
+        "required" : [ "functionType" ],
+        "type" : "object",
+        "properties" : {
+          "functionType" : {
+            "type" : "string",
+            "enum" : [ "PRE_ACTION_EXECUTION", "PRE_FETCH_OPTIONS", "POST_FETCH_OPTIONS", "POST_ACTION_EXECUTION" ]
+          },
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PublicActionRevision" : {
+        "required" : [ "createdAt", "definition", "id", "revisionId" ],
+        "type" : "object",
+        "properties" : {
+          "revisionId" : {
+            "type" : "string"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "definition" : {
+            "$ref" : "#/components/schemas/PublicActionDefinition"
+          },
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "CallbackCompletionRequest" : {
+        "required" : [ "outputFields" ],
+        "type" : "object",
+        "properties" : {
+          "outputFields" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "CollectionResponsePublicActionDefinitionForwardPaging" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "paging" : {
+            "$ref" : "#/components/schemas/ForwardPaging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicActionDefinition"
+            }
+          }
+        }
+      },
+      "Error" : {
+        "required" : [ "category", "correlationId", "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ],
+              "invalidPropertyName" : [ "propertyValue" ]
+            }
+          },
+          "correlationId" : {
+            "type" : "string",
+            "description" : "A unique identifier for the request. Include this value with any error reports or support tickets",
+            "format" : "uuid",
+            "example" : "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : "A map of link names to associated URIs containing documentation about the error or recommended remediation steps",
+            "example" : {
+              "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate",
+            "example" : "Invalid input (details will vary based on the error)"
+          },
+          "category" : {
+            "type" : "string",
+            "description" : "The error category",
+            "example" : "VALIDATION_ERROR"
+          },
+          "errors" : {
+            "type" : "array",
+            "description" : "further information about the error",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          }
+        },
+        "example" : {
+          "message" : "Invalid input (details will vary based on the error)",
+          "correlationId" : "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+          "category" : "VALIDATION_ERROR",
+          "links" : {
+            "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+          }
+        }
+      },
+      "CollectionResponsePublicActionRevisionForwardPaging" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "paging" : {
+            "$ref" : "#/components/schemas/ForwardPaging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicActionRevision"
+            }
+          }
+        }
+      },
+      "PublicActionDefinitionEggInputFieldDependencies" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/PublicSingleFieldDependency"
+        }, {
+          "$ref" : "#/components/schemas/PublicConditionalSingleFieldDependency"
+        } ]
+      },
+      "CallbackCompletionBatchRequest" : {
+        "required" : [ "callbackId", "outputFields" ],
+        "type" : "object",
+        "properties" : {
+          "outputFields" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "callbackId" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PublicActionDefinitionEgg" : {
+        "required" : [ "actionUrl", "functions", "inputFields", "labels", "objectTypes", "published" ],
+        "type" : "object",
+        "properties" : {
+          "inputFields" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/InputFieldDefinition"
+            }
+          },
+          "outputFields" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OutputFieldDefinition"
+            }
+          },
+          "archivedAt" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "functions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicActionFunction"
+            }
+          },
+          "actionUrl" : {
+            "type" : "string"
+          },
+          "inputFieldDependencies" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicActionDefinitionEggInputFieldDependencies"
+            }
+          },
+          "published" : {
+            "type" : "boolean"
+          },
+          "executionRules" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicExecutionTranslationRule"
+            }
+          },
+          "objectTypes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "objectRequestOptions" : {
+            "$ref" : "#/components/schemas/PublicObjectRequestOptions"
+          },
+          "labels" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/PublicActionLabels"
+            }
+          }
+        }
+      },
+      "PublicActionDefinitionPatch" : {
+        "type" : "object",
+        "properties" : {
+          "inputFields" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/InputFieldDefinition"
+            }
+          },
+          "outputFields" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OutputFieldDefinition"
+            }
+          },
+          "actionUrl" : {
+            "type" : "string"
+          },
+          "inputFieldDependencies" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicActionDefinitionPatchInputFieldDependencies"
+            }
+          },
+          "published" : {
+            "type" : "boolean"
+          },
+          "executionRules" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicExecutionTranslationRule"
+            }
+          },
+          "objectTypes" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "objectRequestOptions" : {
+            "$ref" : "#/components/schemas/PublicObjectRequestOptions"
+          },
+          "labels" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/PublicActionLabels"
+            }
+          }
+        }
+      },
+      "BatchInputCallbackCompletionBatchRequest" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CallbackCompletionBatchRequest"
+            }
+          }
+        }
+      },
+      "PublicActionDefinitionPatchInputFieldDependencies" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/PublicSingleFieldDependency"
+        }, {
+          "$ref" : "#/components/schemas/PublicConditionalSingleFieldDependency"
+        } ]
+      },
+      "Option" : {
+        "required" : [ "description", "displayOrder", "doubleData", "hidden", "label", "readOnly", "value" ],
+        "type" : "object",
+        "properties" : {
+          "hidden" : {
+            "type" : "boolean"
+          },
+          "displayOrder" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "doubleData" : {
+            "type" : "number"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "readOnly" : {
+            "type" : "boolean"
+          },
+          "label" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        }
+      },
+      "OutputFieldDefinition" : {
+        "required" : [ "typeDefinition" ],
+        "type" : "object",
+        "properties" : {
+          "typeDefinition" : {
+            "$ref" : "#/components/schemas/FieldTypeDefinition"
+          }
+        }
+      },
+      "NextPage" : {
+        "required" : [ "after" ],
+        "type" : "object",
+        "properties" : {
+          "link" : {
+            "type" : "string"
+          },
+          "after" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "responses" : {
+      "Error" : {
+        "description" : "An error occurred.",
+        "content" : {
+          "*/*" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "oauth2_legacy" : {
+        "type" : "oauth2",
+        "flows" : {
+          "authorizationCode" : {
+            "authorizationUrl" : "https://app.hubspot.com/oauth/authorize",
+            "tokenUrl" : "https://api.hubapi.com/oauth/v1/token",
+            "scopes" : {
+              "automation" : "Read from and write to my Workflows"
+            }
+          }
+        }
+      },
+      "developer_hapikey" : {
+        "type" : "apiKey",
+        "name" : "hapikey",
+        "in" : "query"
+      },
+      "private_apps_legacy" : {
+        "type" : "apiKey",
+        "name" : "private-app-legacy",
+        "in" : "header",
+        "x-ballerina-name" : "privateAppLegacy"
+      }
+    }
+  },
+  "x-hubspot-available-client-libraries" : [ "PHP", "Node", "Ruby", "Python" ],
+  "x-hubspot-product-tier-requirements" : {
+    "marketing" : "PROFESSIONAL",
+    "sales" : "PROFESSIONAL",
+    "service" : "PROFESSIONAL"
+  },
+  "x-hubspot-documentation-banner" : "NONE"
+}

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,6 +1,6 @@
 _Author_:  <!-- TODO: Add author name --> \
 _Created_: <!-- TODO: Add date --> \
-_Updated_: <!-- TODO: Add date --> \
+_Updated_: 2026/06/17 \\
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification
@@ -9,12 +9,10 @@ This document records the sanitation done on top of the official OpenAPI specifi
 The OpenAPI specification is obtained from (TODO: Add source link).
 These changes are done in order to improve the overall usability, and as workarounds for some known language limitations.
 
-
 1. **Change the `url` property of the `servers` object**:
    - **Original**: `https://api.hubapi.com`
    - **Updated**: `https://api.hubapi.com/automation/v4/actions`
    - **Reason**: This change is made to ensure that all API paths are relative to the URL (`/automation/v4/actions`), which improves the consistency and usability of the APIs.
-
 
 2. **Update API Paths**:
    - **Original**: Paths shared a common segment across all resource endpoints.


### PR DESCRIPTION
## Purpose

The Ballerina client generator builds doc comments solely from the OpenAPI `summary` field. Previously, only `description` was AI-improved, leaving `summary` fields as terse single words (e.g. "Read", "Archive", "Update") that produced unhelpful doc comments. This PR improves the developer experience by replacing those with concise, meaningful action phrases and adding field-level descriptions to generated types.

Fixes [wso2/product-integrator#1701](https://github.com/wso2/product-integrator/issues/1701)

## Changes

- Replace terse single-word operation summaries in `client.bal` with concise action phrases that accurately describe each operation, e.g. "Read" → "Retrieve a record by ID", "Archive" → "Archive a record by ID", "Update" → "Update a record by ID", "List" → "Retrieve a page of records".

- Condense any overlong summaries to fit the 35-character doc-comment cap.

- Add missing summaries where absent (e.g. search operations).

- Add AI-generated field-level descriptions to `types.bal` to improve generated documentation.

- Refresh `sanitations.md` with updated regeneration timestamp and add `aligned_ballerina_openapi.json` and `flattened_openapi.json` spec artifacts.

## Examples

**Before:**
```ballerina
# Read
resource isolated function get records/[string recordId](...) { }

# Archive
resource isolated function delete records/[string recordId](...) { }

# Update
resource isolated function patch records/[string recordId](...) { }
```

**After:**
```ballerina
# Retrieve a record by ID
resource isolated function get records/[string recordId](...) { }

# Archive a record by ID
resource isolated function delete records/[string recordId](...) { }

# Update a record by ID
resource isolated function patch records/[string recordId](...) { }
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility